### PR TITLE
Update Python Event template with working example

### DIFF
--- a/scripts/templates/All.Python
+++ b/scripts/templates/All.Python
@@ -51,8 +51,6 @@ other useful details are contained in the following global variables:
  * sunset_in_minutes
  * (TODO) security
 
-TODO: wiki page
-
 Compare to Lua, instead of filling a commandArray, you change the status of a
 device by calling device.on() or device.off()
 
@@ -60,19 +58,19 @@ TODO: setting variables
 
 Calling Python's print function will not print to the domoticz console, see below
 """
-import domoticz
-import random
+import DomoticzEvents as DE
 
-print ("This will only show up in the shell where you start domoticz");
-domoticz.log("Hi Domoticz!")
+DE.Log("Python: Changed: " + DE.changed_device.Describe())
 
-domoticz.log("The device that got changed is: ", changed_device_name)
-# changed_device.name is the same string
+if DE.changed_device_name == "Test":
+    if DE.Devices["Test_Target"].n_value_string == "On":
+        DE.Command("Test_Target", "Off")
 
-for name, device in domoticz.devices.items():
-  domoticz.log("device", name, "is", "on" if device.is_on() else "off")
-  if device.is_off():
-      domoticz.log("could turn it on in 3 seconds")
-      #device.on(after=3)
-for name, value in user_variables.items():
-  domoticz.log("var", name, "has value", value)
+    if DE.Devices["Test_Target"].n_value_string == "Off":
+        DE.Command("Test_Target", "On")
+
+DE.Log("Python: Number of user_variables: " + str(len(DE.user_variables)))
+
+# All user_variables are treated as strings, convert as necessary
+for key, value in DE.user_variables.items():
+    DE.Log("Python: User-variable '{0}' has value: {1}".format(key, value))


### PR DESCRIPTION
Current template was completely outdated and not working, throwing errors.
Python content is now the same as scripts/python/script_device_demo.py